### PR TITLE
Fix font issues in guide

### DIFF
--- a/guide/guide.css
+++ b/guide/guide.css
@@ -128,7 +128,7 @@ pre {
 
     white-space: pre;
     color: #666;
-    font-family: 'Inconsolata', 'Courier', monspace;
+    font-family: 'Inconsolata', 'Courier', monospace;
     font-size: 0.9em;
     font-weight: 500;
     letter-spacing: 0;


### PR DESCRIPTION
Fixed an issue on line 168, where `monospace` was spelled `monspace`, causing font issues on my mac.